### PR TITLE
Fixed typos as part of the protocol definition

### DIFF
--- a/lib/protocol.coffee
+++ b/lib/protocol.coffee
@@ -46,7 +46,7 @@ class Protocol extends events.EventEmitter
     winchl: (value) -> return parseInt(value, 16)
     wintmp: (value) -> return parseInt(value, 16)
     chime: (value) -> return parseInt(value)
-    smokealaert: (value) -> return value # ON/OFF
+    smokealert: (value) -> return value # ON/OFF
     pir: (value) -> return value # ON/OFF
     co2: (value) -> return parseInt(value)
     sound: (value) -> return parseInt(value)
@@ -100,7 +100,7 @@ class Protocol extends events.EventEmitter
     winchl: (value) -> return value.toString(16)
     wintmp: (value) -> return value.toString(16)
     chime: (value) -> return value.toString()
-    smokealaert: (value) -> return value # ON/OFF
+    smokealert: (value) -> return value # ON/OFF
     pir: (value) -> return value # ON/OFF
     co2: (value) -> return value.toString()
     sound: (value) -> return value.toString()


### PR DESCRIPTION
See also http://sourceforge.net/p/rflink/svn/HEAD/tree/Doc/RFLink%20Protocol%20Reference.txt
